### PR TITLE
Fix /el delete not removing links; register el.default permission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Fixed
+- `/el delete` now actually removes the link from storage (previously reported success without removing it)
+- Registered the missing `el.default` permission node for the base `/el` banner command
+
 ## [Initial Release]
 
 ### Added

--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -4,6 +4,7 @@ All commands use `/el` or `/easylinks` as the base.
 
 | Command | Description | Permission |
 |---------|-------------|------------|
+| `/el` | View the plugin banner (name, version, wiki link). | `el.default` |
 | `/el help` | View a list of commands. | `el.help` |
 | `/el list` | List all saved links. | `el.list` |
 | `/el view <name>` | View the URL for a saved link. | `el.view` |

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -20,6 +20,7 @@ Easy Links is a Spigot plugin that lets server administrators save named URLs so
 
 | Permission | Default | Description |
 |------------|---------|-------------|
+| `el.default` | `true` | View the plugin banner (running `/el` with no arguments). |
 | `el.help` | `true` | View the help menu. |
 | `el.list` | `true` | List all saved links. |
 | `el.view` | `true` | View a link's URL. |

--- a/pom.xml
+++ b/pom.xml
@@ -29,6 +29,11 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.2.5</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
                 <version>3.2.4</version>
                 <executions>
@@ -79,6 +84,12 @@
             <artifactId>ponder</artifactId>
             <version>1.0</version>
             <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.10.2</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 </project>

--- a/src/main/java/dansplugins/easylinks/data/PersistentData.java
+++ b/src/main/java/dansplugins/easylinks/data/PersistentData.java
@@ -32,12 +32,11 @@ public class PersistentData {
     }
 
     public boolean removeLink(String label) {
-        for (Link link : links) {
-            if (link.getLabel().equalsIgnoreCase(label)) {
-                return true;
-            }
+        Link linkToRemove = getLink(label);
+        if (linkToRemove == null) {
+            return false;
         }
-        return false;
+        return links.remove(linkToRemove);
     }
 
     public int getTotalUses() {

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -8,6 +8,8 @@ commands:
   el:
 
 permissions:
+  el.default:
+    default: true
   el.help:
     default: true
   el.list:

--- a/src/test/java/dansplugins/easylinks/data/PersistentDataTest.java
+++ b/src/test/java/dansplugins/easylinks/data/PersistentDataTest.java
@@ -1,0 +1,64 @@
+package dansplugins.easylinks.data;
+
+import dansplugins.easylinks.objects.Link;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class PersistentDataTest {
+    private PersistentData persistentData;
+
+    @BeforeEach
+    void setUp() {
+        persistentData = new PersistentData();
+    }
+
+    @Test
+    void removeLink_removesMatchingLinkFromStorage() {
+        persistentData.addLink(new Link("discord", "https://discord.gg/example"));
+
+        boolean result = persistentData.removeLink("discord");
+
+        assertTrue(result);
+        assertEquals(0, persistentData.getLinks().size());
+        assertNull(persistentData.getLink("discord"));
+    }
+
+    @Test
+    void removeLink_isCaseInsensitive() {
+        persistentData.addLink(new Link("Discord", "https://discord.gg/example"));
+
+        boolean result = persistentData.removeLink("discord");
+
+        assertTrue(result);
+        assertEquals(0, persistentData.getLinks().size());
+    }
+
+    @Test
+    void removeLink_returnsFalseWhenLabelNotFound() {
+        persistentData.addLink(new Link("discord", "https://discord.gg/example"));
+
+        boolean result = persistentData.removeLink("nonexistent");
+
+        assertFalse(result);
+        assertEquals(1, persistentData.getLinks().size());
+    }
+
+    @Test
+    void removeLink_onlyRemovesMatchingLink() {
+        persistentData.addLink(new Link("discord", "https://discord.gg/example"));
+        persistentData.addLink(new Link("wiki", "https://example.com/wiki"));
+
+        boolean result = persistentData.removeLink("discord");
+
+        assertTrue(result);
+        assertEquals(1, persistentData.getLinks().size());
+        assertNull(persistentData.getLink("discord"));
+        assertNotNull(persistentData.getLink("wiki"));
+    }
+}


### PR DESCRIPTION
<!-- gardener-tend-dispatch -->
## Summary
- Fix `PersistentData.removeLink` so `/el delete "label"` actually removes the link instead of just reporting success (it iterated the set looking for a match but never called `remove(...)`).
- Register the `el.default` permission node in `plugin.yml` — `DefaultCommand` required it, but it was missing from the permissions list (unlike every other player-facing permission, which defaults to `true`).
- Update `COMMANDS.md`/`USER_GUIDE.md` to document the bare `/el` banner command and its `el.default` permission, and add a CHANGELOG entry.
- Add the project's first automated test suite (JUnit 5 + surefire) with a regression test for the `removeLink` bug — confirmed FAIL before the fix / PASS after via `git stash`.

## Test plan
- [x] `mvn test` — 4/4 tests pass
- [x] `mvn clean package` — full CI-equivalent build succeeds
- [x] Regression test empirically confirmed: fails against the pre-fix `removeLink`, passes against the fix

## Issues
Closes #6
Closes #7

Deferred (recorded, not in scope for this PR — both require a design decision beyond a small bug-fix batch):
- #8 — `debugMode` config option documented as enabling logging but has no effect
- #9 — `StatsCommand` shows placeholder `-1` / `(TBD)` output

## Self-review rubric
- **Scope:** PASS — every changed file is necessary for #6/#7 (fix + permission + its doc rows + test infra); no unrelated formatting/renames.
- **Tests-new:** PASS — `removeLink` (the only new behavior-bearing logic) has 4 new tests covering match, case-insensitivity, no-match, and multi-link isolation.
- **Tests-fix (empirical):** PASS — `git stash`-ed `PersistentData.java`, re-ran `mvn test`: 3 of 4 tests failed as expected against the pre-fix code (`expected: <0> but was: <1>`, etc.); popped the stash and all 4 passed again.
- **Sibling structure:** PASS — new `COMMANDS.md`/`USER_GUIDE.md` rows match the existing table column format; new test file follows a plain JUnit 5 class, no existing test dir to diverge from.
- **Sibling renames:** N/A — no renames in this PR.
- **Docs:** PASS — `COMMANDS.md`, `USER_GUIDE.md`, and `CHANGELOG.md` all reflect the new `el.default` permission and the delete-bug fix.
- **Issue resolution:** PASS — #6's exact method (`removeLink`) and #7's exact gap (`el.default` in `plugin.yml`) are both directly changed.
- **Permissions:** PASS — `el.default` now appears in `src/main/resources/plugin.yml` under `permissions:`.
- **CI:** PASS — `mvn clean package` (matching `.github/workflows/build.yml`) succeeds locally; will re-confirm on the PR's own CI run.


---

_This PR description was drafted during a Gardener session ([Stephenson-Software/gardener](https://github.com/Stephenson-Software/gardener))._
