### PR TITLE
Implement real link usage stats and debugMode logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Added
+- `/el stats` now reports real usage data: total uses is summed from actual per-link use counts, and the most popular link is the one with the most uses (`/el view` increments a link's use count on each successful lookup)
+- Debug logging to the console, gated on the `debugMode` config option, at config-option-set and link storage load/save points
+
 ### Fixed
 - `/el delete` now actually removes the link from storage (previously reported success without removing it)
 - Registered the missing `el.default` permission node for the base `/el` banner command

--- a/src/main/java/dansplugins/easylinks/EasyLinks.java
+++ b/src/main/java/dansplugins/easylinks/EasyLinks.java
@@ -23,7 +23,7 @@ public class EasyLinks extends PonderBukkitPlugin {
 
     private final CommandService commandService = new CommandService(getPonder());
     private final PersistentData persistentData = new PersistentData();
-    private final StorageService storageService = new StorageService(persistentData);
+    private final StorageService storageService = new StorageService(this, persistentData);
     private final ConfigService configService = new ConfigService(this);
 
     /**
@@ -76,6 +76,16 @@ public class EasyLinks extends PonderBukkitPlugin {
             return false;
         } else {
             return !configVersion.equalsIgnoreCase(this.getVersion());
+        }
+    }
+
+    /**
+     * Logs a message to the console if the debugMode config option is enabled.
+     * @param message The message to log.
+     */
+    public void debug(String message) {
+        if (configService.getBoolean("debugMode")) {
+            getLogger().info("[Debug] " + message);
         }
     }
 

--- a/src/main/java/dansplugins/easylinks/commands/ViewCommand.java
+++ b/src/main/java/dansplugins/easylinks/commands/ViewCommand.java
@@ -44,6 +44,8 @@ public class ViewCommand extends AbstractPluginCommand {
             return false;
         }
 
+        link.setUses(link.getUses() + 1);
+
         commandSender.sendMessage(ChatColor.AQUA + " === " + link.getLabel() + " === ");
         commandSender.sendMessage(ChatColor.AQUA + link.getUrl());
         return true;

--- a/src/main/java/dansplugins/easylinks/data/PersistentData.java
+++ b/src/main/java/dansplugins/easylinks/data/PersistentData.java
@@ -40,10 +40,24 @@ public class PersistentData {
     }
 
     public int getTotalUses() {
-        return -1;
+        int totalUses = 0;
+        for (Link link : links) {
+            totalUses += link.getUses();
+        }
+        return totalUses;
     }
 
     public String getMostPopularLink() {
-        return "(TBD)";
+        if (links.isEmpty()) {
+            return "N/A";
+        }
+
+        Link mostPopularLink = null;
+        for (Link link : links) {
+            if (mostPopularLink == null || link.getUses() > mostPopularLink.getUses()) {
+                mostPopularLink = link;
+            }
+        }
+        return mostPopularLink.getLabel();
     }
 }

--- a/src/main/java/dansplugins/easylinks/services/ConfigService.java
+++ b/src/main/java/dansplugins/easylinks/services/ConfigService.java
@@ -61,6 +61,7 @@ public class ConfigService {
             // save
             easyLinks.saveConfig();
             altered = true;
+            easyLinks.debug("Config option '" + option + "' set to '" + value + "'.");
         } else {
             sender.sendMessage(ChatColor.RED + "That config option wasn't found.");
         }

--- a/src/main/java/dansplugins/easylinks/services/StorageService.java
+++ b/src/main/java/dansplugins/easylinks/services/StorageService.java
@@ -1,5 +1,6 @@
 package dansplugins.easylinks.services;
 
+import dansplugins.easylinks.EasyLinks;
 import dansplugins.easylinks.data.PersistentData;
 import dansplugins.easylinks.objects.Link;
 import preponderous.ponder.misc.JsonWriterReader;
@@ -10,13 +11,15 @@ import java.util.*;
  * @author Daniel McCoy Stephenson
  */
 public class StorageService {
+    private final EasyLinks easyLinks;
     private final PersistentData persistentData;
 
     private final static String FILE_PATH = "./plugins/EasyLinks/";
     private final static String LINKS_FILE_NAME = "links.json";
     private final JsonWriterReader jsonWriterReader = new JsonWriterReader();
 
-    public StorageService(PersistentData persistentData) {
+    public StorageService(EasyLinks easyLinks, PersistentData persistentData) {
+        this.easyLinks = easyLinks;
         this.persistentData = persistentData;
         jsonWriterReader.initialize(FILE_PATH);
     }
@@ -35,6 +38,7 @@ public class StorageService {
             links.add(link.save());
         }
         jsonWriterReader.writeOutFiles(links, LINKS_FILE_NAME);
+        easyLinks.debug("Saved " + links.size() + " link(s) to storage.");
     }
 
 
@@ -47,5 +51,6 @@ public class StorageService {
             links.add(link);
         }
         persistentData.setLinks(links);
+        easyLinks.debug("Loaded " + links.size() + " link(s) from storage.");
     }
 }

--- a/src/test/java/dansplugins/easylinks/data/PersistentDataTest.java
+++ b/src/test/java/dansplugins/easylinks/data/PersistentDataTest.java
@@ -61,4 +61,38 @@ class PersistentDataTest {
         assertNull(persistentData.getLink("discord"));
         assertNotNull(persistentData.getLink("wiki"));
     }
+
+    @Test
+    void getTotalUses_returnsZeroWhenNoLinksExist() {
+        assertEquals(0, persistentData.getTotalUses());
+    }
+
+    @Test
+    void getTotalUses_sumsUsesAcrossAllLinks() {
+        Link discord = new Link("discord", "https://discord.gg/example");
+        discord.setUses(3);
+        Link wiki = new Link("wiki", "https://example.com/wiki");
+        wiki.setUses(5);
+        persistentData.addLink(discord);
+        persistentData.addLink(wiki);
+
+        assertEquals(8, persistentData.getTotalUses());
+    }
+
+    @Test
+    void getMostPopularLink_returnsPlaceholderWhenNoLinksExist() {
+        assertEquals("N/A", persistentData.getMostPopularLink());
+    }
+
+    @Test
+    void getMostPopularLink_returnsLabelOfLinkWithHighestUses() {
+        Link discord = new Link("discord", "https://discord.gg/example");
+        discord.setUses(3);
+        Link wiki = new Link("wiki", "https://example.com/wiki");
+        wiki.setUses(5);
+        persistentData.addLink(discord);
+        persistentData.addLink(wiki);
+
+        assertEquals("wiki", persistentData.getMostPopularLink());
+    }
 }


### PR DESCRIPTION
## Summary

- `PersistentData.getTotalUses()` and `getMostPopularLink()` were hardcoded to `-1` and `"(TBD)"`. These are now computed from real per-link use counts, and `ViewCommand` increments a link's use count on each successful lookup. The zero-links case is handled by returning `"N/A"` for the most popular link.
- The `debugMode` config option was documented in `CONFIG.md` as enabling console logging but had no effect anywhere in the codebase. A `debug(String)` helper was added to `EasyLinks`, gated on `debugMode`, and is now called from `ConfigService.setConfigOption` and from `StorageService`'s save/load paths.
- `CHANGELOG.md` was updated with an `Added` entry describing both changes.

An unrelated pre-existing gap was noticed during this work: `StorageService.save()` is never invoked anywhere in the codebase (not even by `CreateCommand`/`DeleteCommand`), so link data — including use counts — is not currently persisted across restarts. That gap is outside the scope of the two issues closed here, so a separate tracking issue is being filed rather than folding a fix into this PR.

This PR description was drafted during a Gardener session (https://github.com/Stephenson-Software/gardener).

## Test plan

- [x] `mvn compile` — clean build
- [x] `mvn test` — 8/8 tests pass, including 4 new tests covering `getTotalUses` and `getMostPopularLink` (empty-links and multi-link cases)
- [x] Manual trace of `ViewCommand.execute` confirms `link.setUses(link.getUses() + 1)` runs only on a successful lookup, before the label/URL is sent to the player

Closes #9
Closes #8

<!-- gardener-tend-dispatch -->