### PR TITLE
Persist link data on mutation and on shutdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - A `Dev Release` workflow, which republishes a rolling `dev` prerelease of `main` on every non-documentation push. This is what Dan's Plugin Manager's experimental channel installs from: `/dpm get easylinks --experimental` reads `releases/tags/dev`, so without it there is nothing for that command to download. The prerelease is unreleased, unreviewed code and is marked as such.
 
+### Fixed
+
+- Links are now actually persisted. `/el create` and `/el delete` write `links.json` immediately, and a shutdown save records the per-link use counts behind `/el stats`. Previously nothing ever called the save routine, so every link and every use count created during a session was discarded on restart.
+- The quoting required by `/el create`, `/el delete` and `/el view` is now documented. `COMMANDS.md` and `USER_GUIDE.md` showed unquoted examples such as `/el view discord`, which the argument parser rejects.
+
 ## [0.4.0-SNAPSHOT-8-8-2026] – 2026-08-08
 
 ### Changed

--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -2,12 +2,14 @@
 
 All commands use `/el` or `/easylinks` as the base.
 
+Arguments must be wrapped in double quotes. A command given unquoted arguments is rejected with its usage message.
+
 | Command | Description | Permission |
 |---------|-------------|------------|
 | `/el` | View the plugin banner (name, version, wiki link). | `el.default` |
 | `/el help` | View a list of commands. | `el.help` |
 | `/el list` | List all saved links. | `el.list` |
-| `/el view <name>` | View the URL for a saved link. | `el.view` |
+| `/el view "<name>"` | View the URL for a saved link. | `el.view` |
 | `/el stats` | View plugin statistics. | `el.stats` |
-| `/el create <name> <url>` | Create a new link. | `el.create` |
-| `/el delete <name>` | Delete a link. | `el.delete` |
+| `/el create "<name>" "<url>"` | Create a new link. | `el.create` |
+| `/el delete "<name>"` | Delete a link. | `el.delete` |

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -12,9 +12,13 @@ Easy Links is a Spigot plugin that lets server administrators save named URLs so
 
 ## Getting Started
 
-1. As an operator, create a link: `/el create discord https://discord.gg/xXtuAQ2`
-2. Players can view it: `/el view discord`
+1. As an operator, create a link: `/el create "discord" "https://discord.gg/xXtuAQ2"`
+2. Players can view it: `/el view "discord"`
 3. List all links: `/el list`
+
+Link names and URLs must be wrapped in double quotes. Without them the command is rejected with its usage message.
+
+Links are written to `plugins/EasyLinks/links.json` as soon as they are created or deleted, and use counts are written when the server shuts down, so both survive a restart.
 
 ## Permissions
 

--- a/src/main/java/dansplugins/easylinks/EasyLinks.java
+++ b/src/main/java/dansplugins/easylinks/EasyLinks.java
@@ -41,6 +41,15 @@ public class EasyLinks extends PonderBukkitPlugin {
     }
 
     /**
+     * This runs when the server stops. Link data is written back to storage so that links created
+     * or deleted during the session, along with their use counts, survive the restart.
+     */
+    @Override
+    public void onDisable() {
+        storageService.save();
+    }
+
+    /**
      * This method handles commands sent to the minecraft server and interprets them if the label matches one of the core commands.
      * @param sender The sender of the command.
      * @param cmd The command that was sent. This is unused.
@@ -114,8 +123,8 @@ public class EasyLinks extends PonderBukkitPlugin {
      */
     private void initializeCommandService() {
         ArrayList<AbstractPluginCommand> commands = new ArrayList<>(Arrays.asList(
-                new HelpCommand(), new CreateCommand(persistentData),
-                new DeleteCommand(persistentData), new ViewCommand(persistentData),
+                new HelpCommand(), new CreateCommand(persistentData, storageService),
+                new DeleteCommand(persistentData, storageService), new ViewCommand(persistentData),
                 new ListCommand(persistentData), new StatsCommand(persistentData)
         ));
         getPonder().getCommandService().initialize(commands, "That command wasn't found.");

--- a/src/main/java/dansplugins/easylinks/commands/CreateCommand.java
+++ b/src/main/java/dansplugins/easylinks/commands/CreateCommand.java
@@ -2,6 +2,7 @@ package dansplugins.easylinks.commands;
 
 import dansplugins.easylinks.data.PersistentData;
 import dansplugins.easylinks.objects.Link;
+import dansplugins.easylinks.services.Storage;
 import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
 
@@ -16,10 +17,12 @@ import java.util.Arrays;
  */
 public class CreateCommand extends AbstractPluginCommand {
     private final PersistentData persistentData;
+    private final Storage storage;
 
-    public CreateCommand(PersistentData persistentData) {
+    public CreateCommand(PersistentData persistentData, Storage storage) {
         super(new ArrayList<>(Arrays.asList("create")), new ArrayList<>(Arrays.asList("el.create")));
         this.persistentData = persistentData;
+        this.storage = storage;
     }
 
     @Override
@@ -41,6 +44,7 @@ public class CreateCommand extends AbstractPluginCommand {
         String link = doubleQuoteArgs.get(1);
         Link newLink = new Link(label, link);
         persistentData.addLink(newLink);
+        storage.save();
         commandSender.sendMessage(ChatColor.GREEN + "Link created.");
         return true;
     }

--- a/src/main/java/dansplugins/easylinks/commands/DeleteCommand.java
+++ b/src/main/java/dansplugins/easylinks/commands/DeleteCommand.java
@@ -1,6 +1,7 @@
 package dansplugins.easylinks.commands;
 
 import dansplugins.easylinks.data.PersistentData;
+import dansplugins.easylinks.services.Storage;
 import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
 
@@ -15,10 +16,12 @@ import java.util.Arrays;
  */
 public class DeleteCommand extends AbstractPluginCommand {
     private final PersistentData persistentData;
+    private final Storage storage;
 
-    public DeleteCommand(PersistentData persistentData) {
+    public DeleteCommand(PersistentData persistentData, Storage storage) {
         super(new ArrayList<>(Arrays.asList("delete")), new ArrayList<>(Arrays.asList("el.delete")));
         this.persistentData = persistentData;
+        this.storage = storage;
     }
 
     @Override
@@ -40,6 +43,7 @@ public class DeleteCommand extends AbstractPluginCommand {
         boolean success = persistentData.removeLink(label);
 
         if (success) {
+            storage.save();
             commandSender.sendMessage(ChatColor.GREEN + "Link deleted.");
             return true;
         }

--- a/src/main/java/dansplugins/easylinks/services/Storage.java
+++ b/src/main/java/dansplugins/easylinks/services/Storage.java
@@ -1,0 +1,18 @@
+package dansplugins.easylinks.services;
+
+/**
+ * The persistence operations that the rest of the plugin depends on.
+ *
+ * @author Daniel McCoy Stephenson
+ */
+public interface Storage {
+    /**
+     * Writes the current state of the plugin's data to disk.
+     */
+    void save();
+
+    /**
+     * Replaces the plugin's data with the state stored on disk.
+     */
+    void load();
+}

--- a/src/main/java/dansplugins/easylinks/services/StorageService.java
+++ b/src/main/java/dansplugins/easylinks/services/StorageService.java
@@ -10,7 +10,7 @@ import java.util.*;
 /**
  * @author Daniel McCoy Stephenson
  */
-public class StorageService {
+public class StorageService implements Storage {
     private final EasyLinks easyLinks;
     private final PersistentData persistentData;
 
@@ -24,10 +24,12 @@ public class StorageService {
         jsonWriterReader.initialize(FILE_PATH);
     }
 
+    @Override
     public void save() {
         saveLinks();
     }
 
+    @Override
     public void load() {
         loadLinks();
     }

--- a/src/test/java/dansplugins/easylinks/commands/CreateCommandTest.java
+++ b/src/test/java/dansplugins/easylinks/commands/CreateCommandTest.java
@@ -1,0 +1,45 @@
+package dansplugins.easylinks.commands;
+
+import dansplugins.easylinks.data.PersistentData;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class CreateCommandTest {
+    private PersistentData persistentData;
+    private RecordingStorage storage;
+    private FakeCommandSender commandSender;
+    private CreateCommand createCommand;
+
+    @BeforeEach
+    void setUp() {
+        persistentData = new PersistentData();
+        storage = new RecordingStorage();
+        commandSender = new FakeCommandSender();
+        createCommand = new CreateCommand(persistentData, storage);
+    }
+
+    @Test
+    void execute_savesTheNewLinkToStorage() {
+        boolean result = createCommand.execute(commandSender.asCommandSender(),
+                new String[]{"\"discord\"", "\"https://discord.gg/example\""});
+
+        assertTrue(result);
+        assertNotNull(persistentData.getLink("discord"));
+        assertEquals(1, storage.getSaveCount());
+    }
+
+    @Test
+    void execute_doesNotSaveWhenArgumentsAreMalformed() {
+        boolean result = createCommand.execute(commandSender.asCommandSender(),
+                new String[]{"discord", "https://discord.gg/example"});
+
+        assertFalse(result);
+        assertEquals(0, persistentData.getLinks().size());
+        assertEquals(0, storage.getSaveCount());
+    }
+}

--- a/src/test/java/dansplugins/easylinks/commands/CreateCommandTest.java
+++ b/src/test/java/dansplugins/easylinks/commands/CreateCommandTest.java
@@ -31,6 +31,7 @@ class CreateCommandTest {
         assertTrue(result);
         assertNotNull(persistentData.getLink("discord"));
         assertEquals(1, storage.getSaveCount());
+        assertTrue(commandSender.getMessages().get(0).endsWith("Link created."));
     }
 
     @Test
@@ -41,5 +42,6 @@ class CreateCommandTest {
         assertFalse(result);
         assertEquals(0, persistentData.getLinks().size());
         assertEquals(0, storage.getSaveCount());
+        assertTrue(commandSender.getMessages().get(0).endsWith("Usage: /el create \"label\" \"link\""));
     }
 }

--- a/src/test/java/dansplugins/easylinks/commands/DeleteCommandTest.java
+++ b/src/test/java/dansplugins/easylinks/commands/DeleteCommandTest.java
@@ -32,6 +32,7 @@ class DeleteCommandTest {
         assertTrue(result);
         assertNull(persistentData.getLink("discord"));
         assertEquals(1, storage.getSaveCount());
+        assertTrue(commandSender.getMessages().get(0).endsWith("Link deleted."));
     }
 
     @Test

--- a/src/test/java/dansplugins/easylinks/commands/DeleteCommandTest.java
+++ b/src/test/java/dansplugins/easylinks/commands/DeleteCommandTest.java
@@ -1,0 +1,45 @@
+package dansplugins.easylinks.commands;
+
+import dansplugins.easylinks.data.PersistentData;
+import dansplugins.easylinks.objects.Link;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class DeleteCommandTest {
+    private PersistentData persistentData;
+    private RecordingStorage storage;
+    private FakeCommandSender commandSender;
+    private DeleteCommand deleteCommand;
+
+    @BeforeEach
+    void setUp() {
+        persistentData = new PersistentData();
+        persistentData.addLink(new Link("discord", "https://discord.gg/example"));
+        storage = new RecordingStorage();
+        commandSender = new FakeCommandSender();
+        deleteCommand = new DeleteCommand(persistentData, storage);
+    }
+
+    @Test
+    void execute_savesTheRemovalToStorage() {
+        boolean result = deleteCommand.execute(commandSender.asCommandSender(), new String[]{"\"discord\""});
+
+        assertTrue(result);
+        assertNull(persistentData.getLink("discord"));
+        assertEquals(1, storage.getSaveCount());
+    }
+
+    @Test
+    void execute_doesNotSaveWhenTheLabelIsNotFound() {
+        boolean result = deleteCommand.execute(commandSender.asCommandSender(), new String[]{"\"nonexistent\""});
+
+        assertFalse(result);
+        assertEquals(1, persistentData.getLinks().size());
+        assertEquals(0, storage.getSaveCount());
+    }
+}

--- a/src/test/java/dansplugins/easylinks/commands/FakeCommandSender.java
+++ b/src/test/java/dansplugins/easylinks/commands/FakeCommandSender.java
@@ -1,0 +1,48 @@
+package dansplugins.easylinks.commands;
+
+import org.bukkit.command.CommandSender;
+
+import java.lang.reflect.Proxy;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A stand-in for Bukkit's {@link CommandSender} that records the messages sent to it.
+ *
+ * A dynamic proxy is used rather than a hand-written implementation because {@link CommandSender}
+ * inherits dozens of permission and server methods that these tests never exercise.
+ */
+class FakeCommandSender {
+    private final List<String> messages = new ArrayList<>();
+    private final CommandSender commandSender;
+
+    FakeCommandSender() {
+        commandSender = (CommandSender) Proxy.newProxyInstance(
+                CommandSender.class.getClassLoader(),
+                new Class<?>[]{CommandSender.class},
+                (proxy, method, args) -> {
+                    if (method.getName().equals("sendMessage") && args != null && args[0] instanceof String) {
+                        messages.add((String) args[0]);
+                    }
+                    return defaultValueFor(method.getReturnType());
+                });
+    }
+
+    CommandSender asCommandSender() {
+        return commandSender;
+    }
+
+    List<String> getMessages() {
+        return messages;
+    }
+
+    private static Object defaultValueFor(Class<?> returnType) {
+        if (returnType == boolean.class) {
+            return false;
+        }
+        if (returnType == int.class) {
+            return 0;
+        }
+        return null;
+    }
+}

--- a/src/test/java/dansplugins/easylinks/commands/RecordingStorage.java
+++ b/src/test/java/dansplugins/easylinks/commands/RecordingStorage.java
@@ -7,7 +7,6 @@ import dansplugins.easylinks.services.Storage;
  */
 class RecordingStorage implements Storage {
     private int saveCount = 0;
-    private int loadCount = 0;
 
     @Override
     public void save() {
@@ -16,14 +15,10 @@ class RecordingStorage implements Storage {
 
     @Override
     public void load() {
-        loadCount++;
+        throw new UnsupportedOperationException("Commands are not expected to load from storage.");
     }
 
     int getSaveCount() {
         return saveCount;
-    }
-
-    int getLoadCount() {
-        return loadCount;
     }
 }

--- a/src/test/java/dansplugins/easylinks/commands/RecordingStorage.java
+++ b/src/test/java/dansplugins/easylinks/commands/RecordingStorage.java
@@ -1,0 +1,29 @@
+package dansplugins.easylinks.commands;
+
+import dansplugins.easylinks.services.Storage;
+
+/**
+ * A {@link Storage} stand-in that counts calls instead of touching the file system.
+ */
+class RecordingStorage implements Storage {
+    private int saveCount = 0;
+    private int loadCount = 0;
+
+    @Override
+    public void save() {
+        saveCount++;
+    }
+
+    @Override
+    public void load() {
+        loadCount++;
+    }
+
+    int getSaveCount() {
+        return saveCount;
+    }
+
+    int getLoadCount() {
+        return loadCount;
+    }
+}


### PR DESCRIPTION
## Summary

- `StorageService.save()` had no call site anywhere in the codebase, so links created or deleted through `/el create` and `/el delete` — and the per-link use counts behind `/el stats` — were held only in memory and discarded on every restart. Saving is now wired up.
- A `Storage` interface (`save()` / `load()`) has been extracted and is implemented by `StorageService`, so the commands can trigger a save without taking a dependency on the plugin instance. This is what makes the behaviour testable, since `StorageService`'s constructor touches the file system.
- `CreateCommand` and `DeleteCommand` save immediately after a successful mutation. `DeleteCommand` saves only on the success branch, so a delete of a nonexistent label does not rewrite the file.
- `EasyLinks.onDisable()` has been added and saves on shutdown. This is what captures the use counts that `/el view` increments; saving on every view was deliberately avoided so that a read-only command does not perform disk I/O on the server thread. The tradeoff is that use counts accumulated since the last create or delete are lost if the server is killed rather than shut down cleanly — links themselves are not affected, as they are written the moment they change.
- `COMMANDS.md` and `USER_GUIDE.md` documented unquoted argument forms (`/el view discord`, `/el create discord https://...`) that the argument parser rejects outright, since every one of those commands requires double-quoted arguments. The placeholders and worked examples have been corrected and the quoting requirement is stated explicitly. This drift is confirmed empirically by `CreateCommandTest.execute_doesNotSaveWhenArgumentsAreMalformed`, which asserts that unquoted arguments produce no link.
- `CHANGELOG.md` records both fixes under `[Unreleased]`.

## Test plan

- [x] `mvn test` — 12 tests, 0 failures (8 pre-existing plus 4 new).
- [x] `mvn compile` clean.
- [x] Regression evidence, empirical rather than reasoned: with the two `storage.save()` calls removed, `CreateCommandTest.execute_savesTheNewLinkToStorage` and `DeleteCommandTest.execute_savesTheRemovalToStorage` both fail (`expected: <1> but was: <0>`); with them restored, all 12 pass.
- [x] New test doubles avoid the file system and Bukkit entirely: `RecordingStorage` counts `save()` calls, and `FakeCommandSender` proxies `CommandSender` to capture messages.
- [ ] Not covered by automation: `onDisable()` cannot be exercised without a running server, so the shutdown save is verified by inspection only. A live restart is worth a smoke test before release.

## Deferred this cycle

Issues left untouched, with reasons, for auditability:

- #16 (the `Easy Links` link seeded in `onEnable()` is always discarded by `load()`) — a maintainer decision is needed on whether the seed is dead scaffolding or an intended default for fresh installations, so it was not resolved unilaterally. It is adjacent to this change but does not block it.
- #17 (`README.md` is a `(TBD)` stub) — writing a README is a self-contained documentation task and would have added unrelated files to this pull request.

Closes #12
Closes #15

---

This PR description was drafted during a Gardener session (https://github.com/Stephenson-Software/gardener).

<!-- gardener-tend-dispatch -->

---

_drafted by Claude on behalf of Daniel Stephenson_