### PR TITLE
Replace the README stub with a real project overview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- A `README.md` describing what the plugin does, how it is installed, a minimal usage example and where the support channels are, with links onward to the user guide, command reference, configuration guide and contributing guide. It previously read `(TBD)`.
 - A `Dev Release` workflow, which republishes a rolling `dev` prerelease of `main` on every non-documentation push. This is what Dan's Plugin Manager's experimental channel installs from: `/dpm get easylinks --experimental` reads `releases/tags/dev`, so without it there is nothing for that command to download. The prerelease is unreleased, unreviewed code and is marked as such.
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Easy Links
 
 ## Description
-Easy Links is a Spigot plugin that lets server administrators save named URLs so that players can look them up in-game with a short command, instead of having long links pasted into chat. Every lookup is counted, and `/el stats` reports how many links exist, how often they have been viewed in total, and which one is the most popular.
+Easy Links is a Spigot plugin that lets server administrators save named URLs so that players can look them up in-game with a short command, instead of having long links pasted into chat. Every successful lookup is counted, and `/el stats` reports how many links exist, how often they have been viewed in total, and which one is the most popular.
 
-Links are stored in `plugins/EasyLinks/links.json`, so they survive a restart.
+Links are stored in `plugins/EasyLinks/links.json`. They are written there as soon as they are created or deleted, and their use counts are written when the server shuts down, so both survive a restart.
 
 ## Installation
 1) Download the latest `EasyLinks-<version>.jar` from the [Releases](https://github.com/Dans-Plugins/Easy-Links/releases) page.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,39 @@
-# Easy-Links
-(TBD)
+# Easy Links
+
+## Description
+Easy Links is a Spigot plugin that lets server administrators save named URLs so that players can look them up in-game with a short command, instead of having long links pasted into chat. Every lookup is counted, and `/el stats` reports how many links exist, how often they have been viewed in total, and which one is the most popular.
+
+Links are stored in `plugins/EasyLinks/links.json`, so they survive a restart.
+
+## Installation
+1) Download the latest `EasyLinks-<version>.jar` from the [Releases](https://github.com/Dans-Plugins/Easy-Links/releases) page.
+2) Once downloaded, place the jar in the plugins folder of your server files.
+3) Restart your server.
+
+A `config.yml` is generated in `plugins/EasyLinks/` on first run. See the [Configuration Guide](CONFIG.md) for the options it contains.
+
+## Usage
+An operator saves a link, and anyone can then look it up:
+
+    /el create "discord" "https://discord.gg/xXtuAQ2"
+    /el view "discord"
+    /el list
+
+Link names and URLs must be wrapped in double quotes. Without them the command is rejected with its usage message.
+
+Creating and deleting links is restricted to operators by default (`el.create` and `el.delete`); viewing, listing and statistics are available to everyone.
+
+### Documentation
+- [User Guide](USER_GUIDE.md) - Installation, getting started and permissions
+- [Commands Reference](COMMANDS.md) - Complete list of all commands
+- [Configuration Guide](CONFIG.md) - Config options
+- [Changelog](CHANGELOG.md) - Notable changes in each release
+
+## Support
+You can find the support discord server [here](https://discord.gg/xXtuAQ2).
+
+### Experiencing a bug?
+Please open an issue [here](https://github.com/Dans-Plugins/Easy-Links/issues).
+
+## Contributing
+- [CONTRIBUTING.md](CONTRIBUTING.md)


### PR DESCRIPTION
## Summary

- `README.md` previously consisted of a heading and the placeholder `(TBD)`, so nothing about the plugin was surfaced on the repository's front page even though `USER_GUIDE.md`, `COMMANDS.md` and `CONFIG.md` already described it accurately.
- A description, installation steps, a minimal usage example and a documentation index have been written, summarised from those documents rather than duplicated, so the existing sources of truth remain single.
- The section structure (`Description` / `Installation` / `Usage` / `Support` / `Contributing`) follows the convention used by sibling Dans-Plugins READMEs.
- Every claim was verified against source: the `/el stats` output line against `StatsCommand`, the use counting against `ViewCommand`, the quoting requirement against the `ArgumentParser` call sites, the `el.create` / `el.delete` operator defaults against `src/main/resources/plugin.yml`, and the `links.json` / `config.yml` paths against `StorageService` and `EasyLinks.configFileExists()`. The wiki URL printed by `/el` was deliberately not cited, as it still points at the pre-transfer `dmccoystephenson` path; that has been filed separately.
- A `CHANGELOG.md` entry has been added under `Unreleased`.

## Deferred this cycle

Issue #16 (the seeded "Easy Links" link discarded by `storageService.load()`) was left untouched: its body records that a maintainer decision is needed between deleting the seed as dead scaffolding and re-applying it as a fresh-install default, and that decision cannot be made autonomously.

## Test plan

- [x] `mvn clean package` — BUILD SUCCESS, 12 tests run, 0 failures, 0 errors
- [x] Relative links (`USER_GUIDE.md`, `COMMANDS.md`, `CONFIG.md`, `CHANGELOG.md`, `CONTRIBUTING.md`) checked against the files present in the repository root
- [x] Documentation sweep across `README.md`, `USER_GUIDE.md`, `COMMANDS.md`, `CONFIG.md`, `CHANGELOG.md` and `plugin.yml` for consistency with this change

Closes #17

<!-- gardener-tend-dispatch -->

---

This PR description was drafted during a Gardener session (https://github.com/Stephenson-Software/gardener).

---

_drafted by Claude on behalf of Daniel Stephenson_